### PR TITLE
addon/install_pyenv: Use PYTHON_VERSION instead of PYTHONVERSION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       language: generic
       env:
         # Used by pyenv
-        - PYTHONVERSION=3.4.5
+        - PYTHON_VERSION=3.4.5
         # Used for testing
         - EXPECTED_PYTHON_VERSION=3.4.5
 
@@ -39,7 +39,7 @@ matrix:
       language: generic
       env:
         # Used by pyenv
-        - PYTHONVERSION=3.3.6
+        - PYTHON_VERSION=3.3.6
         # Used for testing
         - EXPECTED_PYTHON_VERSION=3.3.6
 
@@ -47,7 +47,7 @@ matrix:
       language: generic
       env:
         # Used by pyenv
-        - PYTHONVERSION=2.7.12
+        - PYTHON_VERSION=2.7.12
         # Used for testing
         - EXPECTED_PYTHON_VERSION=2.7.12
 

--- a/docs/addons.rst
+++ b/docs/addons.rst
@@ -305,14 +305,14 @@ Example::
 
 Usage::
 
-  export PYTHONVERSION=X.Y.Z
+  export PYTHON_VERSION=X.Y.Z
   python install_pyenv.py
 
 .. note::
 
     - Update the version of ``pyenv`` using ``brew``.
 
-    - Install the version of python selected setting ``PYTHONVERSION``
+    - Install the version of python selected setting ``PYTHON_VERSION``
       environment variable.
 
 
@@ -320,9 +320,9 @@ Usage::
 ^^^^^^^^^^^^^^^^^^^^^
 
 This is a wrapper script setting the environment corresponding to the
-version selected setting ``PYTHONVERSION`` environment variable.
+version selected setting ``PYTHON_VERSION`` environment variable.
 
 Usage::
   
-    export PYTHONVERSION=X.Y.Z
+    export PYTHON_VERSION=X.Y.Z
     run-with-pyenv.sh python --version

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -16,7 +16,7 @@ before_install:
   travis:
     osx:
       environment:
-        PATH: $<HOME>/.pyenv/versions/$<PYTHONVERSION>/bin:$<PATH>
+        PATH: $<HOME>/.pyenv/versions/$<PYTHON_VERSION>/bin:$<PATH>
       commands:
         - python -m ci_addons travis/install_pyenv
 

--- a/travis/install_pyenv.py
+++ b/travis/install_pyenv.py
@@ -116,4 +116,4 @@ def install(py_version):
     _log("  ->", "found")
 
 if __name__ == '__main__':
-    install(os.environ['PYTHONVERSION'])
+    install(os.environ['PYTHON_VERSION'])

--- a/travis/run-with-pyenv.sh
+++ b/travis/run-with-pyenv.sh
@@ -5,8 +5,8 @@ set -e
 echo "+ eval \"\$( pyenv init - )\""
 eval "$( pyenv init - )"
 
-echo "+ pyenv local \$PYTHONVERSION"
-pyenv local $PYTHONVERSION
+echo "+ pyenv local \$PYTHON_VERSION"
+pyenv local $PYTHON_VERSION
 
 echo "+ eval \"\$@\""
 eval "$@"


### PR DESCRIPTION
Environment variable used in appveyor and travis are not the same.