### PR TITLE
tests: Fix failing "python_check_version" on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ environment:
       PYTHON_ARCH: "32"
       BLOCK: "0"
       # Used for testing
-      EXPECTED_PYTHON_VERSION: 3.5.2
+      EXPECTED_PYTHON_VERSION: 3.5.3
       EXPECTED_PYTHON_ARCH: 32
 
     - PYTHON_DIR: "C:\\Python35-x64"
@@ -39,7 +39,7 @@ environment:
       PYTHON_ARCH: "64"
       BLOCK: "0"
       # Used for testing
-      EXPECTED_PYTHON_VERSION: 3.5.2
+      EXPECTED_PYTHON_VERSION: 3.5.3
       EXPECTED_PYTHON_ARCH: 64
 
 cache:


### PR DESCRIPTION
AppVeyor images have been updated to use python 3.5.3
instead of 3.5.2