### PR TITLE
windows/install-python: fix installation with pip on Python 3

### DIFF
--- a/windows/install-python.ps1
+++ b/windows/install-python.ps1
@@ -101,11 +101,10 @@ param (
   [string]$package
   )
 
-  $pip = Join-Path $pythonDir "Scripts\\pip.exe"
+  $interpreter = Join-Path $pythonDir "python.exe"
+  Write-Host "Installing $package using pip with $interpreter"
 
-  Write-Host "Installing $package using $pip"
-
-  Start-Process $pip -ArgumentList "install `"$package`"" -NoNewWindow -Wait
+  Start-Process $interpreter -ArgumentList "-m pip install `"$package`"" -NoNewWindow -Wait
 }
 
 $downloadDir = "C:/Downloads"


### PR DESCRIPTION
Python 3 does not have Scripts/pip.exe when called. Use the upstream
recommended way of calling pip with '-m'.

@jbvimort please test and report your results.