### PR TITLE
Cast major and minor version to int

### DIFF
--- a/windows/install-cmake.ps1
+++ b/windows/install-cmake.ps1
@@ -16,8 +16,8 @@ if (!$cmakeVersion) {
 
 $version = $cmakeVersion
 
-$major = $version.Split(".")[0]
-$minor = $version.Split(".")[1]
+$major = [int]$version.Split(".")[0]
+$minor = [int]$version.Split(".")[1]
 
 $arch = "win64-x64"
 


### PR DESCRIPTION
When `major` and `minor` are not casted to `int`, the comparison of CMake version  `3.10.1` will detect that `10` is less than `6` and therefore download CMake win32-86 for versions where the first digit of `major` is less than `6` instead of comparing the whole number. The comparison would work again for values greater than 60, and break again above 100 without casting.