### PR TITLE
BUG: Fix regex for Python FTP links

### DIFF
--- a/windows/install-python.ps1
+++ b/windows/install-python.ps1
@@ -235,7 +235,7 @@ foreach ($version in $exeVersions) {
   $split = $version.Split(".")
   $majorMinor = [string]::Join("", $split, 0, 2)
   $majorMinorDot = [string]::Join(".", $split, 0, 2)
-  $xyzVersion = [regex]::Replace($version, "(\d+\.\d+\.\d+).+", '$1')
+  $xyzVersion = [regex]::Replace($version, "(\d+\.\d+\.\d+).*", '$1')
 
   if($pythonVersion -And ! $pythonVersion.CompareTo($majorMinor) -eq 0) {
     Write-Host "Skipping $majorMinor"


### PR DESCRIPTION
Fixes a previously-dormant regex issue that resulted in broken Python download links for updated Python versions.

## Previous behavior

Regex match appears intended to remove non-numeric characters from requested build such that URL is always `<major>.<minor>.<revision>` (no platform modifiers, pre/post-release strings, etc). Original regex erroneous required a trailing character for match. With single-digit revision numbers (`3.8.6`, etc) the capture/replace would fail, but recently updating to double-digit revisions (`3.8.10`) captured/replaced all but the trailing digit (`0`), leading to Python download failures such as in https://github.com/InsightSoftwareConsortium/ITKElastix/actions/runs/3388395908/jobs/5633312524

## Updated behavior

Numeric major.minor.revision values are capture/replaced and _optional_ trailing characters discarded.

## Notes

I am not sure whether this regex matching is actually solving a necessary problem. We specify build numbers directly above and could simply require that no special versions be specified for download. However this fix seemed like the minimum path forward.

cc @thewtex @jcfr 