### PR TITLE
Set security protocol in Windows PowerShell install scripts

### DIFF
--- a/windows/install-python.ps1
+++ b/windows/install-python.ps1
@@ -20,9 +20,25 @@ $downloadDir = "C:/Downloads"
 New-Item -ItemType Directory -Force -Path $downloadDir;
 
 if (![System.IO.File]::Exists("$downloadDir\install-utils.ps1")) {
+  $securityProtocolSettingsOriginal = [System.Net.ServicePointManager]::SecurityProtocol
+
+  try {
+    # Set TLS 1.2, then TLS 1.1.
+    # See https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12 -bor [System.Net.SecurityProtocolType]::Tls11
+  } catch {
+    Write-Warning "Unable to set PowerShell to use TLS 1.2 and TLS 1.1. "`
+      "This may occur because your PowerShell's .NET version does not support one of these protocols."`
+      "If you see underlying connection closed or trust errors, you may need to manually configure the"`
+      "PowerShell security protocol or use a different PowerShell version. "`
+      "See https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-6.0 for protocol types."
+  }
+
   Write-Host "Download install-utils.ps1"
   $url = "https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-utils.ps1"
   (new-object net.webclient).DownloadFile($url, "$downloadDir\install-utils.ps1")
+
+  [System.Net.ServicePointManager]::SecurityProtocol = $securityProtocolSettingsOriginal
 }
 Import-Module "$downloadDir\install-utils.ps1" -Force
 

--- a/windows/install-utils.ps1
+++ b/windows/install-utils.ps1
@@ -11,13 +11,15 @@ param (
   $securityProtocolSettingsOriginal = [System.Net.ServicePointManager]::SecurityProtocol
 
   try {
-    # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
-    # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
-    # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
-    # installed (.NET 4.5 is an in-place upgrade).
-    [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+    # Set TLS 1.2, then TLS 1.1.
+    # See https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-7.0
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12 -bor [System.Net.SecurityProtocolType]::Tls11
   } catch {
-    Write-Warning 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to do one or more of the following: (1) upgrade to .NET Framework 4.5 and PowerShell v3, (2) specify internal Chocolatey package location (set $env:chocolateyDownloadUrl prior to install or host the package internally), (3) use the Download + PowerShell method of install. See https://chocolatey.org/install for all install options.'
+    Write-Warning "Unable to set PowerShell to use TLS 1.2 and TLS 1.1. "`
+      "This may occur because your PowerShell's .NET version does not support one of these protocols."`
+      "If you see underlying connection closed or trust errors, you may need to manually configure the"`
+      "PowerShell security protocol or use a different PowerShell version. "`
+      "See https://learn.microsoft.com/en-us/dotnet/api/system.net.securityprotocoltype?view=net-6.0 for protocol types."
   }
 
   Write-Host "Download $url"


### PR DESCRIPTION
Addresses errors where utilities could not be installed in PowerShell
7.2.9 due to the security protocol not being set.

It appears that SSL3 is obsolete and TLS 1.0 is deprecated. Both protocols are removed
from the list of security protocols to try to set.

The previous error message was misleading and has been updated for
better future proofing.

Resolves an issue in building ITK remote modules where SSL3 is not supported in PowerShell
7.2.9 in GitHub Actions `windows-2022` runners, so PowerShell is not set to use TLS 1.2
for fetching sources from python.org, therefore fetching sometimes fails.

xref https://github.com/InsightSoftwareConsortium/itk-wasm/actions/runs/4053853776/jobs/6982667101

With these changes ITK module builds successfully fetch Python sources using `install_python.ps1`: https://github.com/tbirdso/ITKSplitComponents/actions/runs/4138506454/jobs/7154995112

cc @thewtex @jcfr 